### PR TITLE
fix: getId()の正規表現を新URLパターンに対応

### DIFF
--- a/app/html/index.html
+++ b/app/html/index.html
@@ -8,6 +8,7 @@
 </head>
 
 <body>
+    <script src="../../app/js/helpers.js"></script>
     <script src="../../app/js/content.js"></script>
     <script src="../../app/js/popup.js"></script>
     <div class="wrapper">

--- a/app/js/content.js
+++ b/app/js/content.js
@@ -11,7 +11,7 @@ class VideoUploader {
     }
 
     async request(setting) {
-        const id = this.getId();
+        const id = VideoUploaderHelpers.extractVideoId(window.location.href);
         if (!id) {
             this.messageSelector('#errrOutputInvalidPage');
             return;
@@ -21,9 +21,9 @@ class VideoUploader {
             this.messageSelector('#errrOutputMissingParameter');
             return;
         }
-        const detail = this.makeDetail(setting.detail);
-        const tags = this.makeTags(setting.tags);
-        const registeredAt = this.formatDateTime(setting.publishHour);
+        const detail = VideoUploaderHelpers.makeDetail(setting.detail);
+        const tags = VideoUploaderHelpers.makeTags(setting.tags);
+        const registeredAt = VideoUploaderHelpers.formatDateTime(setting.publishHour);
         const payload = this.makePayload(
             id,
             title,
@@ -111,36 +111,10 @@ class VideoUploader {
         }
     }
 
-    getId() {
-        const currentPageUrl = window.location.href;
-        const regex = /videos\/(?:sm)?(\d+)/;
-        const match = currentPageUrl.match(regex);
-        return match ? parseInt(match[1], 10) : null;
-    }
-
     makeTitle(title) {
         const textPlaceHolder = '{{defaultInput}}';
         const titleElement = document.querySelector('input[name="title"]');
         return title.replace(textPlaceHolder, titleElement.value);
-    }
-
-    makeDetail(detail) {
-        return detail.replace(/\n/g, '<br>');
-    }
-
-    makeTags(tags) {
-        return tags.split(' ');
-    }
-
-    formatDateTime(hour) {
-        console.log("formatDateTime");
-        console.log(hour);
-        if (typeof hour === 'undefined') {
-            return null;
-        }
-        const now = new Date();
-        now.setHours(hour, 0, 0, 0);
-        return `${now.getFullYear()}-${(now.getMonth() + 1).toString().padStart(2, '0')}-${now.getDate().toString().padStart(2, '0')}T${now.getHours().toString().padStart(2, '0')}:00:00+09:00`;
     }
 
     messageSelector(messageId) {

--- a/app/js/content.js
+++ b/app/js/content.js
@@ -113,7 +113,7 @@ class VideoUploader {
 
     getId() {
         const currentPageUrl = window.location.href;
-        const regex = /sm(\d+)/;
+        const regex = /videos\/(?:sm)?(\d+)/;
         const match = currentPageUrl.match(regex);
         return match ? parseInt(match[1], 10) : null;
     }

--- a/app/js/helpers.js
+++ b/app/js/helpers.js
@@ -1,0 +1,28 @@
+const VideoUploaderHelpers = {
+    extractVideoId(url) {
+        const regex = /videos\/(?:sm)?(\d+)/;
+        const match = url.match(regex);
+        return match ? parseInt(match[1], 10) : null;
+    },
+
+    makeDetail(detail) {
+        return detail.replace(/\n/g, '<br>');
+    },
+
+    makeTags(tags) {
+        return tags.split(' ');
+    },
+
+    formatDateTime(hour) {
+        if (typeof hour === 'undefined') {
+            return null;
+        }
+        const now = new Date();
+        now.setHours(hour, 0, 0, 0);
+        return `${now.getFullYear()}-${(now.getMonth() + 1).toString().padStart(2, '0')}-${now.getDate().toString().padStart(2, '0')}T${now.getHours().toString().padStart(2, '0')}:00:00+09:00`;
+    }
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = VideoUploaderHelpers;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "niconico Upload helper",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "ニコニコ動画の動画アップロードヘルパー",
     "permissions": [
         "scripting",

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,7 @@
                 "https://garage.nicovideo.jp/niconico-garage/video/videos/*"
             ],
             "js": [
+                "app/js/helpers.js",
                 "app/js/content.js"
             ]
         }

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -1,40 +1,66 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
+const helpers = require('../app/js/helpers.js');
 
-/**
- * getId() の正規表現ロジックを抽出したヘルパー関数。
- * VideoUploader クラスは window.location や chrome API に依存しているため、
- * 正規表現マッチ部分だけを独立してテストする。
- */
-function extractVideoId(url) {
-    const regex = /videos\/(?:sm)?(\d+)/;
-    const match = url.match(regex);
-    return match ? parseInt(match[1], 10) : null;
-}
-
-describe('getId() の正規表現ロジック', () => {
+describe('extractVideoId', () => {
     it('新URL形式: videos/ の後に数字のみ', () => {
         const url = 'https://garage.nicovideo.jp/niconico-garage/video/videos/46183109';
-        assert.strictEqual(extractVideoId(url), 46183109);
+        assert.strictEqual(helpers.extractVideoId(url), 46183109);
     });
 
     it('旧URL形式: videos/ の後に sm プレフィックス付き', () => {
         const url = 'https://garage.nicovideo.jp/niconico-garage/video/videos/sm46183109';
-        assert.strictEqual(extractVideoId(url), 46183109);
+        assert.strictEqual(helpers.extractVideoId(url), 46183109);
     });
 
     it('無効なURL: videos/ を含まない', () => {
         const url = 'https://example.com/';
-        assert.strictEqual(extractVideoId(url), null);
+        assert.strictEqual(helpers.extractVideoId(url), null);
     });
 
-    it('エッジケース: URLに videos/ が含まれない場合', () => {
+    it('videos/ がパスに含まれない場合', () => {
         const url = 'https://garage.nicovideo.jp/niconico-garage/video/sm46183109';
-        assert.strictEqual(extractVideoId(url), null);
+        assert.strictEqual(helpers.extractVideoId(url), null);
     });
 
-    it('エッジケース: ポート番号など他の数字に誤マッチしない', () => {
+    it('ポート番号など他の数字に誤マッチしない', () => {
         const url = 'https://example.com:8080/path/12345';
-        assert.strictEqual(extractVideoId(url), null);
+        assert.strictEqual(helpers.extractVideoId(url), null);
+    });
+});
+
+describe('makeDetail', () => {
+    it('改行を<br>に変換する', () => {
+        assert.strictEqual(helpers.makeDetail('line1\nline2\nline3'), 'line1<br>line2<br>line3');
+    });
+
+    it('改行がない場合はそのまま返す', () => {
+        assert.strictEqual(helpers.makeDetail('no newlines'), 'no newlines');
+    });
+});
+
+describe('makeTags', () => {
+    it('スペース区切りの文字列を配列にする', () => {
+        assert.deepStrictEqual(helpers.makeTags('tag1 tag2 tag3'), ['tag1', 'tag2', 'tag3']);
+    });
+
+    it('タグが1つの場合は要素1の配列', () => {
+        assert.deepStrictEqual(helpers.makeTags('single'), ['single']);
+    });
+});
+
+describe('formatDateTime', () => {
+    it('hourがundefinedの場合はnullを返す', () => {
+        assert.strictEqual(helpers.formatDateTime(undefined), null);
+    });
+
+    it('有効な時間を渡すとISO形式の文字列を返す', () => {
+        const result = helpers.formatDateTime(15);
+        assert.match(result, /^\d{4}-\d{2}-\d{2}T15:00:00\+09:00$/);
+    });
+
+    it('0時を渡した場合', () => {
+        const result = helpers.formatDateTime(0);
+        assert.match(result, /^\d{4}-\d{2}-\d{2}T00:00:00\+09:00$/);
     });
 });

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -1,0 +1,40 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+/**
+ * getId() の正規表現ロジックを抽出したヘルパー関数。
+ * VideoUploader クラスは window.location や chrome API に依存しているため、
+ * 正規表現マッチ部分だけを独立してテストする。
+ */
+function extractVideoId(url) {
+    const regex = /videos\/(?:sm)?(\d+)/;
+    const match = url.match(regex);
+    return match ? parseInt(match[1], 10) : null;
+}
+
+describe('getId() の正規表現ロジック', () => {
+    it('新URL形式: videos/ の後に数字のみ', () => {
+        const url = 'https://garage.nicovideo.jp/niconico-garage/video/videos/46183109';
+        assert.strictEqual(extractVideoId(url), 46183109);
+    });
+
+    it('旧URL形式: videos/ の後に sm プレフィックス付き', () => {
+        const url = 'https://garage.nicovideo.jp/niconico-garage/video/videos/sm46183109';
+        assert.strictEqual(extractVideoId(url), 46183109);
+    });
+
+    it('無効なURL: videos/ を含まない', () => {
+        const url = 'https://example.com/';
+        assert.strictEqual(extractVideoId(url), null);
+    });
+
+    it('エッジケース: URLに videos/ が含まれない場合', () => {
+        const url = 'https://garage.nicovideo.jp/niconico-garage/video/sm46183109';
+        assert.strictEqual(extractVideoId(url), null);
+    });
+
+    it('エッジケース: ポート番号など他の数字に誤マッチしない', () => {
+        const url = 'https://example.com:8080/path/12345';
+        assert.strictEqual(extractVideoId(url), null);
+    });
+});


### PR DESCRIPTION
## Summary
- `getId()` の正規表現を `/sm(\d+)/` から `/videos\/(?:sm)?(\d+)/` に変更し、新旧両方のURLパターンに対応
- `videos/` をアンカーにすることで、ポート番号等への誤マッチを防止
- `node:test` / `node:assert` を使ったテストを `test/content.test.js` に追加（5ケース）

Closes #20

## Test plan
- [x] 新URL形式 (`videos/46183109`) からIDを正しく取得できること
- [x] 旧URL形式 (`videos/sm46183109`) からIDを正しく取得できること
- [x] 無効なURL (`https://example.com/`) で null を返すこと
- [x] `videos/` を含まないURLで null を返すこと
- [x] ポート番号など他の数字に誤マッチしないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)