### PR TITLE
feat: Chrome Web Store への自動アップロード機能を追加

### DIFF
--- a/.github/docs/chrome-webstore-setup.md
+++ b/.github/docs/chrome-webstore-setup.md
@@ -1,0 +1,133 @@
+# Chrome Web Store 自動アップロード セットアップガイド
+
+## 概要
+
+GitHub Actions から Chrome Web Store API を使って拡張機能のアップロード・公開を自動化する仕組みです。
+
+## 1. Google Cloud プロジェクトの設定
+
+### 1-1. プロジェクト作成
+
+1. [Google Cloud Console](https://console.cloud.google.com/) にアクセス
+2. 新しいプロジェクトを作成（または既存プロジェクトを使用）
+
+### 1-2. Chrome Web Store API の有効化
+
+1. [APIライブラリ](https://console.cloud.google.com/apis/library) を開く
+2. 「Chrome Web Store API」を検索して有効化
+
+### 1-3. OAuth2 認証情報の作成
+
+1. [認証情報](https://console.cloud.google.com/apis/credentials) を開く
+2. 「認証情報を作成」→「OAuth クライアント ID」
+3. アプリケーションの種類: 「デスクトップアプリ」
+4. 作成後、**クライアントID** と **クライアントシークレット** をメモ
+
+### 1-4. リフレッシュトークンの取得
+
+ブラウザで以下のURLにアクセス（`{CLIENT_ID}` を置換）:
+
+```
+https://accounts.google.com/o/oauth2/auth?response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&client_id={CLIENT_ID}&redirect_uri=urn:ietf:wg:oauth:2.0:oob
+```
+
+承認後に表示される認可コードを使って、トークンを取得:
+
+```bash
+curl -s -X POST "https://oauth2.googleapis.com/token" \
+  -d "client_id={CLIENT_ID}" \
+  -d "client_secret={CLIENT_SECRET}" \
+  -d "code={AUTH_CODE}" \
+  -d "grant_type=authorization_code" \
+  -d "redirect_uri=urn:ietf:wg:oauth:2.0:oob"
+```
+
+レスポンスの `refresh_token` をメモする。
+
+> **注意**: `redirect_uri=urn:ietf:wg:oauth:2.0:oob` は Google が廃止予定としています。
+> 動作しない場合は、ローカルサーバーを使ったフロー（localhost redirect）に切り替えてください。
+> 参考: https://developers.google.com/identity/protocols/oauth2/native-app
+
+## 2. GitHub Secrets の設定
+
+リポジトリの **Settings > Secrets and variables > Actions** で以下を登録:
+
+| Secret 名 | 値 | 説明 |
+|---|---|---|
+| `CHROME_EXTENSION_ID` | 拡張機能のID | Chrome Web Store の URL から取得（`https://chrome.google.com/webstore/detail/{ID}`） |
+| `CHROME_CLIENT_ID` | OAuth2 クライアントID | 手順 1-3 で取得 |
+| `CHROME_CLIENT_SECRET` | OAuth2 クライアントシークレット | 手順 1-3 で取得 |
+| `CHROME_REFRESH_TOKEN` | OAuth2 リフレッシュトークン | 手順 1-4 で取得 |
+
+## 3. 使い方
+
+### 手動実行（推奨）
+
+1. GitHub リポジトリの **Actions** タブを開く
+2. 左メニューから **Chrome Web Store Upload** を選択
+3. **Run workflow** をクリック
+4. オプションを選択:
+   - **dry-run**: チェックするとアップロードせずバリデーションのみ実行
+   - **publish**: チェックするとアップロード後に公開リクエストも送信
+
+**初回は必ず dry-run で実行し、問題がないことを確認してください。**
+
+### タグプッシュによる自動実行
+
+```bash
+git tag v0.1.2
+git push origin v0.1.2
+```
+
+タグプッシュ時は**アップロードのみ**（公開はしない）で実行されます。
+公開は手動で Developer Dashboard から、または workflow_dispatch で `--publish` を指定して行います。
+
+## 4. 操作リスク低減の措置
+
+### 4-1. 段階的な安全機構
+
+| 層 | 措置 | 説明 |
+|---|---|---|
+| **トリガー** | workflow_dispatch が主トリガー | 意図しない自動実行を防止 |
+| **タグ検証** | タグ ↔ manifest.json バージョン一致チェック | バージョン不整合によるアップロードを防止 |
+| **dry-run** | `--dry-run` オプション | 実際のAPIコールなしで全バリデーションを実行 |
+| **upload/publish 分離** | デフォルトはアップロードのみ | 公開は明示的なオプション指定が必要 |
+| **アーティファクト保存** | ZIPを90日間保存 | アップロード内容の事後確認が可能 |
+| **Secrets** | GitHub Secrets で認証情報を管理 | コードに認証情報を含めない |
+
+### 4-2. トークン失効時の対応
+
+リフレッシュトークンが失効した場合:
+
+1. ワークフローの「アクセストークン取得」ステップでエラーが出る
+2. 手順 1-4 を再実行して新しいリフレッシュトークンを取得
+3. GitHub Secrets の `CHROME_REFRESH_TOKEN` を更新
+
+> Google OAuth2 のリフレッシュトークンは、以下の場合に失効します:
+> - 6ヶ月間使用しなかった場合
+> - ユーザーがアクセスを取り消した場合
+> - Google Cloud プロジェクトが「テスト」ステータスのまま（7日間で失効）
+>
+> **重要**: Google Cloud プロジェクトを「本番」に昇格させると、トークンの有効期間制限がなくなります。
+
+### 4-3. 公開の取り消し
+
+Chrome Web Store に公開した場合:
+
+1. [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole) にアクセス
+2. 該当の拡張機能を選択
+3. 「非公開」に変更することでストアから取り下げ可能
+
+ただし、審査が完了して公開済みのバージョンは即座に取り下げても、既にインストール済みのユーザーには影響しません。
+
+### 4-4. 推奨運用フロー
+
+```
+1. コードを修正・テスト
+2. manifest.json のバージョンを更新
+3. main にマージ
+4. workflow_dispatch で dry-run 実行 → 問題ないことを確認
+5. workflow_dispatch で publish=false 実行 → アップロード確認
+6. Developer Dashboard で内容を目視確認
+7. workflow_dispatch で publish=true 実行 → 公開
+```

--- a/.github/scripts/chrome-webstore-upload.sh
+++ b/.github/scripts/chrome-webstore-upload.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Chrome Web Store API を使って拡張機能をアップロード・公開する
+#
+# 必要な環境変数:
+#   CHROME_EXTENSION_ID  - Chrome Web Store の拡張機能ID
+#   CHROME_CLIENT_ID     - Google OAuth2 クライアントID
+#   CHROME_CLIENT_SECRET - Google OAuth2 クライアントシークレット
+#   CHROME_REFRESH_TOKEN - Google OAuth2 リフレッシュトークン
+#
+# 使い方:
+#   chrome-webstore-upload.sh <ZIPファイル> [--publish] [--dry-run]
+#
+set -euo pipefail
+
+# --- 引数パース ---
+ZIP_FILE=""
+PUBLISH=false
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --publish)  PUBLISH=true; shift ;;
+    --dry-run)  DRY_RUN=true; shift ;;
+    *)          ZIP_FILE="$1"; shift ;;
+  esac
+done
+
+if [ -z "$ZIP_FILE" ]; then
+  echo "Error: ZIPファイルを指定してください" >&2
+  echo "使い方: $0 <ZIPファイル> [--publish] [--dry-run]" >&2
+  exit 1
+fi
+
+if [ ! -f "$ZIP_FILE" ]; then
+  echo "Error: ファイルが見つかりません: $ZIP_FILE" >&2
+  exit 1
+fi
+
+# --- 環境変数チェック ---
+MISSING_VARS=()
+for VAR in CHROME_EXTENSION_ID CHROME_CLIENT_ID CHROME_CLIENT_SECRET CHROME_REFRESH_TOKEN; do
+  if [ -z "${!VAR:-}" ]; then
+    MISSING_VARS+=("$VAR")
+  fi
+done
+
+if [ ${#MISSING_VARS[@]} -gt 0 ]; then
+  echo "Error: 以下の環境変数が設定されていません:" >&2
+  printf '  - %s\n' "${MISSING_VARS[@]}" >&2
+  echo "" >&2
+  echo "GitHub リポジトリの Settings > Secrets and variables > Actions で設定してください。" >&2
+  echo "詳細は .github/docs/chrome-webstore-setup.md を参照してください。" >&2
+  exit 1
+fi
+
+# --- dry-run モード ---
+if [ "$DRY_RUN" = true ]; then
+  echo "=== DRY-RUN モード ==="
+  echo "ZIPファイル: $ZIP_FILE ($(du -h "$ZIP_FILE" | cut -f1))"
+  echo "拡張機能ID: $CHROME_EXTENSION_ID"
+  echo "公開: $([ "$PUBLISH" = true ] && echo 'する' || echo 'しない（アップロードのみ）')"
+  echo ""
+  echo "ZIPの内容:"
+  unzip -l "$ZIP_FILE" | tail -n +4 | head -n -2
+  echo ""
+
+  # manifest.json のバージョン確認
+  MANIFEST_VERSION=$(unzip -p "$ZIP_FILE" manifest.json | grep -o '"version": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+  echo "manifest.json バージョン: $MANIFEST_VERSION"
+  echo ""
+  echo "=== dry-run 完了（実際のアップロードは行いません）==="
+  exit 0
+fi
+
+# --- アクセストークン取得 ---
+echo "=== アクセストークン取得 ==="
+TOKEN_RESPONSE=$(curl -s -X POST "https://oauth2.googleapis.com/token" \
+  -d "client_id=${CHROME_CLIENT_ID}" \
+  -d "client_secret=${CHROME_CLIENT_SECRET}" \
+  -d "refresh_token=${CHROME_REFRESH_TOKEN}" \
+  -d "grant_type=refresh_token")
+
+ACCESS_TOKEN=$(echo "$TOKEN_RESPONSE" | grep -o '"access_token": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+
+if [ -z "$ACCESS_TOKEN" ]; then
+  echo "Error: アクセストークンの取得に失敗しました" >&2
+  echo "レスポンス: $TOKEN_RESPONSE" >&2
+  echo "" >&2
+  echo "考えられる原因:" >&2
+  echo "  - CHROME_CLIENT_ID / CHROME_CLIENT_SECRET が正しくない" >&2
+  echo "  - CHROME_REFRESH_TOKEN の有効期限が切れている" >&2
+  echo "  - Google Cloud Console でChrome Web Store APIが有効化されていない" >&2
+  exit 1
+fi
+echo "アクセストークン取得成功"
+
+# --- アップロード ---
+echo "=== 拡張機能アップロード ==="
+echo "ファイル: $ZIP_FILE"
+echo "拡張機能ID: $CHROME_EXTENSION_ID"
+
+UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X PUT \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "x-goog-api-version: 2" \
+  -T "$ZIP_FILE" \
+  "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}")
+
+UPLOAD_HTTP_CODE=$(echo "$UPLOAD_RESPONSE" | tail -1)
+UPLOAD_BODY=$(echo "$UPLOAD_RESPONSE" | sed '$d')
+
+if [ "$UPLOAD_HTTP_CODE" -ne 200 ]; then
+  echo "Error: アップロードに失敗しました (HTTP $UPLOAD_HTTP_CODE)" >&2
+  echo "$UPLOAD_BODY" >&2
+  echo "" >&2
+  echo "考えられる原因:" >&2
+  echo "  - CHROME_EXTENSION_ID が正しくない" >&2
+  echo "  - manifest.json のバージョンが既存と同じ" >&2
+  echo "  - ZIPファイルのフォーマットが不正" >&2
+  exit 1
+fi
+
+# uploadState を確認
+UPLOAD_STATE=$(echo "$UPLOAD_BODY" | grep -o '"uploadState": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+if [ "$UPLOAD_STATE" != "SUCCESS" ]; then
+  echo "Error: アップロードは完了しましたが、状態が SUCCESS ではありません: $UPLOAD_STATE" >&2
+  echo "$UPLOAD_BODY" >&2
+  exit 1
+fi
+
+echo "アップロード成功"
+
+# --- 公開 ---
+if [ "$PUBLISH" = true ]; then
+  echo "=== 拡張機能を公開 ==="
+  PUBLISH_RESPONSE=$(curl -s -w "\n%{http_code}" \
+    -X POST \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    -H "x-goog-api-version: 2" \
+    -H "Content-Length: 0" \
+    "https://www.googleapis.com/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}/publish")
+
+  PUBLISH_HTTP_CODE=$(echo "$PUBLISH_RESPONSE" | tail -1)
+  PUBLISH_BODY=$(echo "$PUBLISH_RESPONSE" | sed '$d')
+
+  if [ "$PUBLISH_HTTP_CODE" -ne 200 ]; then
+    echo "Error: 公開に失敗しました (HTTP $PUBLISH_HTTP_CODE)" >&2
+    echo "$PUBLISH_BODY" >&2
+    echo "" >&2
+    echo "アップロードは成功しています。手動でChrome Web Store Developer Dashboardから公開できます。" >&2
+    exit 1
+  fi
+
+  PUBLISH_STATUS=$(echo "$PUBLISH_BODY" | grep -o '"status"\s*:\s*\[\s*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+  echo "公開リクエスト完了 (status: ${PUBLISH_STATUS:-確認中})"
+  echo "注意: Chrome Web Store の審査が完了するまで公開は反映されません"
+else
+  echo ""
+  echo "アップロードのみ完了しました（公開はしていません）"
+  echo "公開するには --publish オプションを付けて再実行するか、"
+  echo "Chrome Web Store Developer Dashboard から手動で公開してください。"
+fi
+
+echo "=== 完了 ==="

--- a/.github/scripts/package-extension.sh
+++ b/.github/scripts/package-extension.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Chrome拡張機能のZIPパッケージを作成する
+#
+# 使い方:
+#   .github/scripts/package-extension.sh [出力ファイル名]
+#
+# 出力ファイル名を省略した場合、manifest.jsonのバージョンからファイル名を生成する
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# manifest.json からバージョン取得
+VERSION=$(grep -o '"version": *"[^"]*"' manifest.json | grep -o '"[^"]*"$' | tr -d '"')
+if [ -z "$VERSION" ]; then
+  echo "Error: manifest.json からバージョンを読み取れませんでした" >&2
+  exit 1
+fi
+
+OUTPUT="${1:-nicoup-v${VERSION}.zip}"
+
+echo "=== nicoup v${VERSION} パッケージ作成 ==="
+
+# 一時ディレクトリで作業
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# パッケージに含めるファイルをコピー
+cp manifest.json "$TMPDIR/"
+cp -r app "$TMPDIR/"
+cp -r resource "$TMPDIR/"
+
+# 不要ファイルを除外
+find "$TMPDIR" -name "memo.md" -delete
+find "$TMPDIR" -name ".DS_Store" -delete
+
+# ZIP作成
+(cd "$TMPDIR" && zip -r -q "$REPO_ROOT/$OUTPUT" .)
+
+echo "パッケージ作成完了: $OUTPUT"
+echo "含まれるファイル:"
+unzip -l "$OUTPUT" | grep -E "^\s+[0-9]" | grep -v "files$"
+
+# バリデーション: manifest.json が含まれているか
+if ! unzip -l "$OUTPUT" | grep -q "manifest.json"; then
+  echo "Error: ZIPにmanifest.jsonが含まれていません" >&2
+  exit 1
+fi
+
+echo "=== 完了 ==="

--- a/.github/workflows/chrome-webstore-upload.yml
+++ b/.github/workflows/chrome-webstore-upload.yml
@@ -1,0 +1,101 @@
+name: Chrome Web Store Upload
+
+on:
+  # 手動実行（主要なトリガー）
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'アップロード後に公開も行う'
+        required: false
+        type: boolean
+        default: false
+      dry-run:
+        description: 'dry-run（実際のアップロードを行わずバリデーションのみ）'
+        required: false
+        type: boolean
+        default: false
+
+  # タグプッシュ時の自動アップロード（公開はしない）
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+
+    # タグプッシュ時は main ブランチのタグのみ許可
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: manifest.json のバージョン確認
+        id: version
+        run: |
+          VERSION=$(grep -o '"version": *"[^"]*"' manifest.json | grep -o '"[^"]*"$' | tr -d '"')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "manifest.json version: $VERSION"
+
+          # タグプッシュ時: タグとmanifestのバージョン一致を検証
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+            if [ "$VERSION" != "$TAG_VERSION" ]; then
+              echo "::error::タグ v${TAG_VERSION} と manifest.json のバージョン ${VERSION} が一致しません"
+              exit 1
+            fi
+          fi
+
+      - name: 拡張機能をパッケージング
+        run: |
+          chmod +x .github/scripts/package-extension.sh
+          .github/scripts/package-extension.sh "nicoup-v${{ steps.version.outputs.version }}.zip"
+
+      - name: パッケージをアーティファクトとして保存
+        uses: actions/upload-artifact@v4
+        with:
+          name: nicoup-v${{ steps.version.outputs.version }}
+          path: nicoup-v${{ steps.version.outputs.version }}.zip
+          retention-days: 90
+
+      - name: Chrome Web Store にアップロード
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: |
+          chmod +x .github/scripts/chrome-webstore-upload.sh
+
+          # オプション組み立て
+          OPTS=""
+          # workflow_dispatch の場合は入力値を使用、タグプッシュ時は公開しない
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ inputs.publish }}" = "true" ]; then
+              OPTS="$OPTS --publish"
+            fi
+            if [ "${{ inputs.dry-run }}" = "true" ]; then
+              OPTS="$OPTS --dry-run"
+            fi
+          fi
+
+          .github/scripts/chrome-webstore-upload.sh \
+            "nicoup-v${{ steps.version.outputs.version }}.zip" \
+            $OPTS
+
+      - name: 結果サマリー
+        if: always()
+        run: |
+          echo "## Chrome Web Store Upload" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **バージョン**: ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **トリガー**: ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "- **dry-run**: ${{ inputs.dry-run }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **公開**: ${{ inputs.publish }}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- **公開**: false（タグプッシュ時はアップロードのみ）" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
### やったこと

GitHub Actions で Chrome Web Store への拡張機能アップロードを自動化

- **パッケージングスクリプト** (`.github/scripts/package-extension.sh`): manifest.json + app/ + resource/ をZIPに固める。memo.md等の不要ファイルは除外
- **アップロードスクリプト** (`.github/scripts/chrome-webstore-upload.sh`): Chrome Web Store API でアップロード・公開。dry-runモード対応
- **ワークフロー** (`.github/workflows/chrome-webstore-upload.yml`): 手動実行(workflow_dispatch) + タグプッシュ(v*)をトリガーに実行
- **セットアップガイド** (`.github/docs/chrome-webstore-setup.md`): OAuth2認証情報の取得手順・GitHub Secrets設定・運用フロー

#### 操作リスク低減の措置

| 措置 | 説明 |
|---|---|
| workflow_dispatch 主トリガー | 意図しない自動公開を防止 |
| dry-run オプション | APIコールなしで全バリデーション実行 |
| upload/publish 分離 | デフォルトはアップロードのみ。公開は明示的指定が必要 |
| タグ ↔ manifest バージョン検証 | バージョン不整合を防止 |
| ZIPアーティファクト保存(90日) | アップロード内容の事後確認が可能 |

### issue

なし（新機能追加）

### 備考

- 利用には GitHub Secrets に4つの認証情報（`CHROME_EXTENSION_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`）の設定が必要
- 設定手順は `.github/docs/chrome-webstore-setup.md` を参照
- Google OAuth2 の `urn:ietf:wg:oauth:2.0:oob` リダイレクトは廃止予定のため、動作しない場合はlocalhostフローへの切り替えが必要