### PR TITLE
chore: バージョンを 0.2.0 に更新

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "niconico Upload helper",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "ニコニコ動画の動画アップロードヘルパー",
     "permissions": [
         "scripting",


### PR DESCRIPTION
## Summary
- Chrome Web Store リリース v0.2.0 に向けて `manifest.json` のバージョンを `0.1.1` → `0.2.0` に更新

## 含まれる変更（v0.1.1 → v0.2.0）
- PR #22: Chrome Web Store 自動アップロード機能
- PR #23: Node.js 22 LTS 移行準備

## Test plan
- [x] manifest.json のバージョンが `0.2.0` であること
- [ ] マージ後 `v0.2.0` タグプッシュで Actions が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)