### PR TITLE
fix: 公開APIの審査中ステータスを成功として扱う

### DIFF
--- a/.github/scripts/chrome-webstore-upload.sh
+++ b/.github/scripts/chrome-webstore-upload.sh
@@ -152,9 +152,17 @@ if [ "$PUBLISH" = true ]; then
     exit 1
   fi
 
-  PUBLISH_STATUS=$(echo "$PUBLISH_BODY" | grep -o '"status"\s*:\s*\[\s*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+  PUBLISH_STATUS=$(echo "$PUBLISH_BODY" | grep -o '"status" *: *\[ *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"') || true
   echo "公開リクエスト完了 (status: ${PUBLISH_STATUS:-確認中})"
-  echo "注意: Chrome Web Store の審査が完了するまで公開は反映されません"
+
+  case "${PUBLISH_STATUS}" in
+    OK)
+      echo "公開が即座に反映されました" ;;
+    ITEM_PENDING_REVIEW)
+      echo "審査待ち: Chrome Web Store の審査が完了すると自動的に公開されます" ;;
+    ""|*)
+      echo "注意: Chrome Web Store の審査が完了するまで公開は反映されません" ;;
+  esac
 else
   echo ""
   echo "アップロードのみ完了しました（公開はしていません）"


### PR DESCRIPTION
## Summary
- Chrome Web Store publish API が `ITEM_PENDING_REVIEW` を返した場合にスクリプトが異常終了する問題を修正
- ステータス抽出の grep を GNU grep 互換に修正（`\s*` → スペース `*`）

## 原因
`set -euo pipefail` 環境下で `grep -o` の `\s*` が GNU grep 基本モードで動作せず、exit code 1 でスクリプトが即終了していた

## Test plan
- [x] `ITEM_PENDING_REVIEW` ステータスが正常終了として扱われること
- [ ] 次回の publish 実行で Actions が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)