### PR TITLE
chore: GitHub Actions を Node.js 24 対応バージョンに更新

### DIFF
--- a/.github/workflows/chrome-webstore-upload.yml
+++ b/.github/workflows/chrome-webstore-upload.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: manifest.json のバージョン確認
         id: version
@@ -55,7 +55,7 @@ jobs:
           .github/scripts/package-extension.sh "nicoup-v${{ steps.version.outputs.version }}.zip"
 
       - name: パッケージをアーティファクトとして保存
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nicoup-v${{ steps.version.outputs.version }}
           path: nicoup-v${{ steps.version.outputs.version }}.zip

--- a/.github/workflows/milestone-closed.yml
+++ b/.github/workflows/milestone-closed.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Create Next Version Milestone
       env:


### PR DESCRIPTION
## Summary
- Node.js 20 の非推奨化警告（2026年6月2日強制移行）に対応
- `actions/checkout` v4 → **v6**
- `actions/upload-artifact` v4 → **v7**

## 対象ファイル
- `.github/workflows/milestone-closed.yml`
- `.github/workflows/chrome-webstore-upload.yml`

## Test plan
- [ ] Actions 実行時に Node.js 20 非推奨警告が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)